### PR TITLE
Add optional_variant api ( not optimized yet, but adding it to our DataBuffer API )

### DIFF
--- a/data_buffer.cpp
+++ b/data_buffer.cpp
@@ -110,6 +110,7 @@ void DataBuffer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("add_vector3", "value", "compression_level"), &DataBuffer::add_vector3, DEFVAL(COMPRESSION_LEVEL_1));
 	ClassDB::bind_method(D_METHOD("add_normalized_vector3", "value", "compression_level"), &DataBuffer::add_normalized_vector3, DEFVAL(COMPRESSION_LEVEL_1));
 	ClassDB::bind_method(D_METHOD("add_variant", "value"), &DataBuffer::add_variant);
+	ClassDB::bind_method(D_METHOD("add_optional_variant", "value"), &DataBuffer::add_optional_variant);
 
 	ClassDB::bind_method(D_METHOD("read_bool"), &DataBuffer::read_bool);
 	ClassDB::bind_method(D_METHOD("read_int", "compression_level"), &DataBuffer::read_int, DEFVAL(COMPRESSION_LEVEL_1));
@@ -122,6 +123,7 @@ void DataBuffer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("read_vector3", "compression_level"), &DataBuffer::read_vector3, DEFVAL(COMPRESSION_LEVEL_1));
 	ClassDB::bind_method(D_METHOD("read_normalized_vector3", "compression_level"), &DataBuffer::read_normalized_vector3, DEFVAL(COMPRESSION_LEVEL_1));
 	ClassDB::bind_method(D_METHOD("read_variant"), &DataBuffer::read_variant);
+	ClassDB::bind_method(D_METHOD("read_optional_variant"), &DataBuffer::read_optional_variant);
 
 	ClassDB::bind_method(D_METHOD("skip_bool"), &DataBuffer::skip_bool);
 	ClassDB::bind_method(D_METHOD("skip_int", "compression_level"), &DataBuffer::skip_int, DEFVAL(COMPRESSION_LEVEL_1));
@@ -153,6 +155,7 @@ void DataBuffer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("read_vector3_size", "compression_level"), &DataBuffer::read_vector3_size, DEFVAL(COMPRESSION_LEVEL_1));
 	ClassDB::bind_method(D_METHOD("read_normalized_vector3_size", "compression_level"), &DataBuffer::read_normalized_vector3_size, DEFVAL(COMPRESSION_LEVEL_1));
 	ClassDB::bind_method(D_METHOD("read_variant_size"), &DataBuffer::read_variant_size);
+	ClassDB::bind_method(D_METHOD("read_optional_variant_size"), &DataBuffer::read_optional_variant_size);
 
 	ClassDB::bind_method(D_METHOD("begin_read"), &DataBuffer::begin_read);
 	ClassDB::bind_method(D_METHOD("begin_write", "meta_size"), &DataBuffer::begin_write);
@@ -917,6 +920,30 @@ Variant DataBuffer::add_variant(const Variant &p_input) {
 	return p_input;
 }
 
+/// This is an optimization for when we want a null Variant to be a single bit in the buffer.
+Variant DataBuffer::add_optional_variant(const Variant &p_input) {
+	if ( p_input.is_null() ){
+		WARN_PRINT(vformat("add_optional_variant's is_null call: %s", "TRUE"));
+		add_bool(true);
+		return p_input;
+	} else {
+		WARN_PRINT(vformat("add_optional_variant's is_null call: %s", "FALSE"));
+		add_bool(false);
+	}
+	return add_variant(p_input);
+}
+
+Variant DataBuffer::read_optional_variant() {
+	const bool is_null = read_bool();
+	if ( is_null ){
+		WARN_PRINT(vformat("read_optional_variant's is_null bool: %s", "TRUE"));
+		return Variant();
+	} else{
+		WARN_PRINT(vformat("read_optional_variant's is_null bool: %s", "FALSE"));
+		return read_variant();
+	}
+}
+
 Variant DataBuffer::read_variant() {
 	ERR_FAIL_COND_V(!is_reading, Variant());
 	Variant ret;
@@ -1205,6 +1232,18 @@ int DataBuffer::read_variant_size() {
 	bit_offset += len * 8;
 
 	return len * 8;
+}
+
+
+int DataBuffer::read_optional_variant_size() {
+	const bool is_null = read_bool();
+	if (is_null) {
+		WARN_PRINT(vformat("read_optional_variant_SIZE's is_null bool: %s", "TRUE"));
+		return get_bool_size();
+	} else {
+		WARN_PRINT(vformat("read_optional_variant_SIZE's is_null bool: %s", "FALSE"));
+		return get_bool_size() + read_variant_size();
+	}
 }
 
 int DataBuffer::get_bit_taken(DataType p_data_type, CompressionLevel p_compression) {

--- a/data_buffer.cpp
+++ b/data_buffer.cpp
@@ -922,26 +922,11 @@ Variant DataBuffer::add_variant(const Variant &p_input) {
 
 /// This is an optimization for when we want a null Variant to be a single bit in the buffer.
 Variant DataBuffer::add_optional_variant(const Variant &p_input) {
-	if ( p_input.is_null() ){
-		WARN_PRINT(vformat("add_optional_variant's is_null call: %s", "TRUE"));
-		add_bool(true);
-		return p_input;
-	} else {
-		WARN_PRINT(vformat("add_optional_variant's is_null call: %s", "FALSE"));
-		add_bool(false);
-	}
 	return add_variant(p_input);
 }
 
 Variant DataBuffer::read_optional_variant() {
-	const bool is_null = read_bool();
-	if ( is_null ){
-		WARN_PRINT(vformat("read_optional_variant's is_null bool: %s", "TRUE"));
-		return Variant();
-	} else{
-		WARN_PRINT(vformat("read_optional_variant's is_null bool: %s", "FALSE"));
-		return read_variant();
-	}
+	return read_variant();
 }
 
 Variant DataBuffer::read_variant() {
@@ -1236,14 +1221,7 @@ int DataBuffer::read_variant_size() {
 
 
 int DataBuffer::read_optional_variant_size() {
-	const bool is_null = read_bool();
-	if (is_null) {
-		WARN_PRINT(vformat("read_optional_variant_SIZE's is_null bool: %s", "TRUE"));
-		return get_bool_size();
-	} else {
-		WARN_PRINT(vformat("read_optional_variant_SIZE's is_null bool: %s", "FALSE"));
-		return get_bool_size() + read_variant_size();
-	}
+	return read_variant_size();
 }
 
 int DataBuffer::get_bit_taken(DataType p_data_type, CompressionLevel p_compression) {

--- a/data_buffer.h
+++ b/data_buffer.h
@@ -307,6 +307,14 @@ public:
 	/// Parse the next data as Variant and returns it.
 	Variant read_variant();
 
+	/// Add a nullable variant. This is a packet size optimization for null cases.
+	/// If that first bool is false, the original variant value was null
+	Variant add_optional_variant(const Variant &p_input);
+
+	/// Parse the next data as an encoded nullable Variant and returns it.
+	/// If that first bool is false, the original variant value was null
+	Variant read_optional_variant();
+
 	/// Add a data buffer to this buffer.
 	void add_data_buffer(const DataBuffer &p_db);
 	void read_data_buffer(DataBuffer &r_db);
@@ -357,6 +365,7 @@ public:
 	int read_vector3_size(CompressionLevel p_compression);
 	int read_normalized_vector3_size(CompressionLevel p_compression);
 	int read_variant_size();
+	int read_optional_variant_size();
 	int read_buffer_size();
 
 	static int get_bit_taken(DataType p_data_type, CompressionLevel p_compression);


### PR DESCRIPTION
Sister PR: https://github.com/the-mirror-megaverse/godot-soft-fork/pull/185

To be used for smaller packet size with optional variant in the buffer.
Like in this commit on the gdscript side: https://github.com/the-mirror-megaverse/mirror-godot-app/pull/1701/commits/fa6eef82de5e3454179d029d7caa7880c09c120f